### PR TITLE
feat(2): QuantitySelector on Product Detail Page

### DIFF
--- a/frontend/src/components/QuantitySelector.jsx
+++ b/frontend/src/components/QuantitySelector.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styles from './QuantitySelector.module.css';
+
+export default function QuantitySelector({ value, min = 1, max, onChange }) {
+  return (
+    <div className={styles.wrapper} role="group" aria-label="Quantity">
+      <button
+        type="button"
+        className={styles.btn}
+        onClick={() => onChange(value - 1)}
+        disabled={value <= min}
+        aria-label="Decrease quantity"
+      >
+        −
+      </button>
+      <span className={styles.display} aria-live="polite" aria-atomic="true">
+        {value}
+      </span>
+      <button
+        type="button"
+        className={styles.btn}
+        onClick={() => onChange(value + 1)}
+        disabled={max !== undefined && value >= max}
+        aria-label="Increase quantity"
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/QuantitySelector.module.css
+++ b/frontend/src/components/QuantitySelector.module.css
@@ -1,0 +1,48 @@
+.wrapper {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--color-surface);
+}
+
+.btn {
+  width: 38px;
+  height: 38px;
+  background: var(--color-bg);
+  border: none;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background 0.15s;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn:hover:not(:disabled) {
+  background: var(--color-border);
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.display {
+  min-width: 44px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  font-weight: 700;
+  border-left: 1px solid var(--color-border);
+  border-right: 1px solid var(--color-border);
+  background: var(--color-surface);
+  padding: 0 4px;
+  user-select: none;
+}

--- a/frontend/src/pages/ProductDetailPage.jsx
+++ b/frontend/src/pages/ProductDetailPage.jsx
@@ -3,6 +3,7 @@ import { useParams, Link } from 'react-router-dom';
 import { useCart } from '../context/CartContext.jsx';
 import RatingStars from '../components/RatingStars.jsx';
 import ProductCard from '../components/ProductCard.jsx';
+import QuantitySelector from '../components/QuantitySelector.jsx';
 import styles from './ProductDetailPage.module.css';
 
 export default function ProductDetailPage() {
@@ -12,6 +13,7 @@ export default function ProductDetailPage() {
   const [related, setRelated] = useState([]);
   const [loading, setLoading] = useState(true);
   const [added, setAdded] = useState(false);
+  const [quantity, setQuantity] = useState(1);
 
   useEffect(() => {
     setLoading(true);
@@ -26,9 +28,14 @@ export default function ProductDetailPage() {
       .finally(() => setLoading(false));
   }, [id]);
 
+  // Reset quantity to 1 whenever the product id changes
+  useEffect(() => {
+    setQuantity(1);
+  }, [id]);
+
   function handleAddToCart() {
     if (!product) return;
-    dispatch({ type: 'addItem', payload: product });
+    dispatch({ type: 'addItem', payload: { ...product, quantity } });
     setAdded(true);
     setTimeout(() => setAdded(false), 2000);
   }
@@ -64,6 +71,14 @@ export default function ProductDetailPage() {
               <span key={tag} className={styles.tag}>{tag}</span>
             ))}
           </div>
+          {product.stock > 0 && (
+            <QuantitySelector
+              value={quantity}
+              min={1}
+              max={product.stock}
+              onChange={setQuantity}
+            />
+          )}
           <button
             className={styles.addBtn}
             onClick={handleAddToCart}


### PR DESCRIPTION
Feature #2 for Issue #6

Adds a reusable QuantitySelector component and integrates it into the Product Detail page.

**Changes:**
- `frontend/src/components/QuantitySelector.jsx` (new) — accepts `value`, `min` (default 1), `max`, `onChange` props; renders `−` / display / `+` row; `-` disabled when `value <= min`, `+` disabled when `value >= max`; `aria-live` on display for accessibility
- `frontend/src/components/QuantitySelector.module.css` (new) — styles
- `frontend/src/pages/ProductDetailPage.jsx` — added `quantity` state (`useState(1)`); `useEffect([id])` resets quantity to 1 on product navigation; renders `<QuantitySelector>` between tags and Add to Cart (hidden when out of stock); dispatch updated to `{ type: 'addItem', payload: { ...product, quantity } }`

`npm run build` ✅ 0 errors

---
*Created by Antigravity Dev Agent*